### PR TITLE
Adding a default value for update_cache

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -38,6 +38,7 @@ options:
       - Default is not to update the cache.
     aliases: [ update-cache ]
     type: bool
+    default: false
   update_cache_retries:
     description:
       - Amount of retries if the cache update fails. Also see O(update_cache_retry_max_delay).


### PR DESCRIPTION
##### SUMMARY

I was just looking at the documentation and realized that almost every entry in the reference table had their default value highlighted. Looking at `update_cache`, I noticed that even though its default value is mentioned in the description, it's not marked like the other default values.
This is of course a purely aesthetic change.

##### ISSUE TYPE

- Docs Pull Request
